### PR TITLE
build fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "subtitle": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
-    "build-watch": "tsc --watch",
+    "build": "tsc -P ./tsconfig.json",
+    "build-watch": "tsc -P ./tsconfig.json --watch",
     "start": "node dist/index.js",
     "server": "cross-env NODE_ENV=development nodemon --watch ./dist dist/index.js",
     "client": "npm start --prefix arab-client",
+    "dev-server": "concurrently \"npm run build-watch\" \"npm run server\"",
     "dev": "concurrently \"npm run build-watch\" \"npm run server\" \"npm run client\"",
     "cleardb": "node dist/cleardb",
     "test": "jest"


### PR DESCRIPTION
I have noticed the build process is working properly in the `dev` npm run script,

but once we start doing the build standalone by it self with it's npm script `npm run build` it can't build all files, even with `npm run build-watch`.

side note that happen in macos, it could be working properly in other platforms.